### PR TITLE
Fix PDNAddressAllocation IPv6 func

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.48
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=1 --timeout=3m0s --tests=false --no-config --max-issues-per-linter=4095 --max-same-issues=1023 --disable-all --enable=deadcode --enable=errcheck --enable=gosimple --enable=govet --enable=ineffassign --enable=staticcheck --enable=structcheck --enable=typecheck --enable=unused --enable=varcheck --enable=bodyclose --enable=dogsled --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=goprintffuncname --enable=gosec --enable=misspell --enable=nakedret --enable=prealloc --enable=rowserrcheck --enable=stylecheck --enable=unconvert --enable=unparam --enable=exportloopref --enable=gomodguard --enable=asciicheck --enable=errorlint
           # Optional: show only new issues if it's a pull request. The default value is `false`.

--- a/gtpv2/ie/ip-addr.go
+++ b/gtpv2/ie/ip-addr.go
@@ -165,13 +165,22 @@ func (i *IE) IPv6() (net.IP, error) {
 	}
 
 	switch i.Type {
-	case IPAddress, PDNAddressAllocation, S103PDNDataForwardingInfo, S1UDataForwarding:
+	case IPAddress, S103PDNDataForwardingInfo, S1UDataForwarding:
 		ip, err := i.IP()
 		if err != nil {
 			return nil, err
 		}
 
 		if v := ip.To16(); v != nil {
+			return v, nil
+		}
+		return nil, ErrIEValueNotFound
+	case PDNAddressAllocation:
+		paa, err := ParsePDNAddressAllocationFields(i.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if v := paa.IPv6Address.To16(); v != nil {
 			return v, nil
 		}
 		return nil, ErrIEValueNotFound


### PR DESCRIPTION
If request contains PDNType ipv46, there is a need to check the IP addresses. By default IP() return ipv4 address. IPv6() was updated and now return ipv6 address or err if address not present.